### PR TITLE
fix: Vision の Date Picker で日付が反映されないバグを修正

### DIFF
--- a/app/charts/[id]/project-editor.tsx
+++ b/app/charts/[id]/project-editor.tsx
@@ -2917,7 +2917,12 @@ export function ProjectEditor({ initialChart, chartId, currentUserId }: ProjectE
       console.log("[handleUpdateVision] 成功");
       // targetDate、assignee、isLockedが変更された場合は即座に反映するため、refreshする
       // contentの場合は画面リセットを避けるため、refreshしない
-      if (field === "targetDate" || field === "assignee" || field === "isLocked") {
+      if (
+        field === "dueDate" ||
+        field === "targetDate" ||
+        field === "assignee" ||
+        field === "isLocked"
+      ) {
         router.refresh();
       }
     } else {

--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -394,6 +394,7 @@ export async function updateVision(
   updates: Partial<VisionItem>
 ): Promise<boolean> {
   try {
+    const serverClient = await createClient();
     const updateData: any = {};
     if (updates.content !== undefined) updateData.content = updates.content;
     if (updates.assignee !== undefined) updateData.assignee = updates.assignee;
@@ -402,7 +403,7 @@ export async function updateVision(
     if (updates.isLocked !== undefined) updateData.is_locked = updates.isLocked;
     if (updates.area_id !== undefined) updateData.area_id = updates.area_id;
 
-    const { error } = await supabase
+    const { error } = await serverClient
       .from("visions")
       .update(updateData)
       .eq("id", visionId)
@@ -420,14 +421,14 @@ export async function updateVision(
 
     if (Object.keys(syncUpdates).length > 0) {
       try {
-        const { data: chart } = await supabase
+        const { data: chart } = await serverClient
           .from("charts")
           .select("parent_action_id")
           .eq("id", chartId)
           .single();
 
         if (chart?.parent_action_id) {
-          await supabase
+          await serverClient
             .from("actions")
             .update({
               ...syncUpdates,


### PR DESCRIPTION
## 原因
- `updateVision` がブラウザ用 Supabase クライアントを使っていたため、サーバー実行時に RLS で弾かれてサイレント失敗していた
- `handleUpdateVision` の `router.refresh()` 条件に dueDate が含まれていなかった

## 修正内容
- `lib/supabase/queries.ts`: `updateVision` のクライアントを `createClient()`（サーバー用）に変更
- `app/charts/[id]/project-editor.tsx`: dueDate 更新時も `router.refresh()` を実行するよう修正

Closes #26