### PR TITLE
fix: エリアタグの付け直し（変更）ができないバグを修正

### DIFF
--- a/app/charts/[id]/project-editor.tsx
+++ b/app/charts/[id]/project-editor.tsx
@@ -2915,13 +2915,20 @@ export function ProjectEditor({ initialChart, chartId, currentUserId }: ProjectE
     const success = await updateVisionItem(id, chartId, field, value);
     if (success) {
       console.log("[handleUpdateVision] 成功");
+      if (field === "areaId") {
+        const areaName = value
+          ? chart.areas.find((area: Area) => area.id === value)?.name
+          : "未分類";
+        toast.success(`${areaName ?? "未分類"} に移動しました`);
+      }
       // targetDate、assignee、isLockedが変更された場合は即座に反映するため、refreshする
       // contentの場合は画面リセットを避けるため、refreshしない
       if (
         field === "dueDate" ||
         field === "targetDate" ||
         field === "assignee" ||
-        field === "isLocked"
+        field === "isLocked" ||
+        field === "areaId"
       ) {
         router.refresh();
       }
@@ -3028,6 +3035,12 @@ export function ProjectEditor({ initialChart, chartId, currentUserId }: ProjectE
     // Server updateのみ（Optimistic UIなし）
     const success = await updateRealityItem(id, chartId, field, value);
     if (success) {
+      if (field === "areaId") {
+        const areaName = value
+          ? chart.areas.find((area: Area) => area.id === value)?.name
+          : "未分類";
+        toast.success(`${areaName ?? "未分類"} に移動しました`);
+      }
       // 成功時はページを再取得
       router.refresh();
     } else {

--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -531,13 +531,14 @@ export async function updateReality(
   updates: Partial<Pick<RealityItem, "content" | "isLocked" | "area_id" | "dueDate">>
 ): Promise<boolean> {
   try {
+    const serverClient = await createClient();
     const updateData: any = {};
     if (updates.content !== undefined) updateData.content = updates.content;
     if (updates.isLocked !== undefined) updateData.is_locked = updates.isLocked;
     if (updates.area_id !== undefined) updateData.area_id = updates.area_id;
     if (updates.dueDate !== undefined) updateData.due_date = updates.dueDate;
 
-    const { error } = await supabase
+    const { error } = await serverClient
       .from("realities")
       .update(updateData)
       .eq("id", realityId)
@@ -628,13 +629,14 @@ export async function updateTension(
   updates: Partial<Pick<Tension, "title" | "description" | "status">>
 ): Promise<boolean> {
   try {
+    const serverClient = await createClient();
     const updateData: any = {};
     if (updates.title !== undefined) updateData.title = updates.title;
     if (updates.description !== undefined)
       updateData.description = updates.description;
     if (updates.status !== undefined) updateData.status = updates.status;
 
-    const { error } = await supabase
+    const { error } = await serverClient
       .from("tensions")
       .update(updateData)
       .eq("id", tensionId)


### PR DESCRIPTION
## 原因
- `updateReality` と `updateTension` がブラウザ用 Supabase クライアントを使っていたため、サーバー実行時に RLS で弾かれてサイレント失敗していた（#26 と同じパターン）
- Vision の `handleUpdateVision` で areaId 変更時に `router.refresh()` が呼ばれていなかった

## 修正内容
- `lib/supabase/queries.ts`: `updateReality` / `updateTension` のクライアントを `createClient()`（サーバー用）に変更
- `project-editor.tsx`: areaId 変更時も `router.refresh()` を実行 + トースト通知を追加（Vision / Reality）

## 動作確認
- Vision / Reality / Tension すべてでエリアタグの付け替えが反映されることを確認済み

Closes #29