### PR TITLE
feat: Workspace関連テーブルのスキーマ追加

### DIFF
--- a/supabase/migrations/add_workspaces.sql
+++ b/supabase/migrations/add_workspaces.sql
@@ -1,0 +1,33 @@
+-- ① workspaces テーブル
+CREATE TABLE IF NOT EXISTS workspaces (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT NOT NULL,
+  owner_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ② workspace_members テーブル
+CREATE TABLE IF NOT EXISTS workspace_members (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'owner' CHECK (role IN ('owner', 'editor', 'viewer')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(workspace_id, user_id)
+);
+
+-- ③ charts に workspace_id を追加
+ALTER TABLE charts ADD COLUMN IF NOT EXISTS workspace_id UUID REFERENCES workspaces(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_charts_workspace_id ON char + 暫定ポリシー
+ALTER TABLE workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workspace_members ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow all operations on workspaces" ON workspaces
+  FOR ALL USING (true) WITH CHECK (true);
+CREAllow all operations on workspace_members" ON workspace_members
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- ⑤ updated_at トリガー
+CREATE TRIGGER update_workspaces_updated_at BEFORE UPDATE ON workspaces
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Phase 1 PR① - DB設計

### 追加テーブル
- workspaces (id, name, owner_id, created_at, updated_at)
- workspace_members (workspace_id, user_id, role, created_at)

### 既存テーブルの変更
- charts に workspace_id カラムを追加（nullable、段階移行のため）

### RLS
- 暫定で全許可（PR③で Workspace ベースに制限予定）

### 備考
- Supabase SQL Editor で実行済み
- ローカルにマイグレーションファイルを追加

Part of #18