### PR TITLE
perf: Vision/Reality/Tension の追加・更新を楽観的UIに変更 (#65)

### DIFF
--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -347,7 +347,6 @@ export async function createVision(
       chart_id: chartId,
       content: content.trim(),
       user_id: user.id,
-      created_by: user.id,
     };
     if (areaId) {
       insertData.area_id = areaId;


### PR DESCRIPTION
## 変更内容
Vision/Reality/Tensionの追加・更新でrouter.refresh()による全ページ再取得を廃止し、楽観的UI（Optimistic UI）に変更。

## 問題
毎回の操作でrevalidatePath + router.refresh()によるフルリロードが走り、入力→反映が数秒かかっていた。

## 解決策
- ローカルStateを即時更新（tempIdで仮追加）
- サーバー保存はバックグラウンド
- 成功時: tempIdを実IDに置換
- 失敗時: ロールバック
- useEffect依存を[initialChart.id]に変更し、Server Action後のState全リセットを防止

## 対象ハンドラー
- handleAddVision / handleAddReality / handleAddTension
- handleUpdateReality

## その他
- createVisionのcreated_byカラム参照を削除（既存バグ修正）