### PR TITLE
feat: restore StatusBar with real action status data on Home

### DIFF
--- a/app/charts/chart-card.tsx
+++ b/app/charts/chart-card.tsx
@@ -15,7 +15,7 @@ export function ChartCard({ chart, isMaster = false }: { chart: ChartWithMeta; i
           ? "3rd"
           : `${chart.depth}th`;
 
-  const mockStatus = {
+  const actionStatus = chart.actionStatusCounts ?? {
     total: 0,
     done: 0,
     inProgress: 0,
@@ -34,7 +34,7 @@ export function ChartCard({ chart, isMaster = false }: { chart: ChartWithMeta; i
         <div className="flex items-start justify-between mb-1">
           <div className="flex items-center gap-2 flex-1 min-w-0">
             <DepthBadge depth={chart.depth} label={depthLabel} />
-            <StatusBar status={mockStatus} />
+            <StatusBar status={actionStatus} />
           </div>
           <div className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-2">
             <DeleteChartButton chartId={chart.id} />


### PR DESCRIPTION
## 概要

Home画面のChartCardに表示されるStatusBar（積み上げプログレスバー）を実データで復旧。

## 変更内容

- `app/charts/actions.ts`: `getActionStatusCountsByChart` を追加。1クエリで全チャートのActionステータスを集計（N+1回避）
- `app/charts/chart-card.tsx`: mockStatus を削除し、実データ（chart.actionStatusCounts）を使用

## テスト結果

- [x] Actionがあるチャート → ステータス分布がバーで表示される
- [x] Actionがないチャート → バー非表示（従来通り）