### PR TITLE
feat: add dashboard period filter with custom date range picker

### DIFF
--- a/app/dashboard/dashboard-chart-filter.tsx
+++ b/app/dashboard/dashboard-chart-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Select,
@@ -8,6 +9,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type DashboardChartFilterProps = {
   charts: { id: string; title: string }[];
@@ -21,6 +24,7 @@ export function DashboardChartFilter({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   const handleChange = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -30,11 +34,20 @@ export function DashboardChartFilter({
       params.set("chartId", value);
     }
     const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname);
+    const newUrl = query ? `${pathname}?${query}` : pathname;
+    startTransition(() => {
+      router.push(newUrl, { scroll: false });
+    });
   };
 
   return (
-    <Select value={selectedChartId} onValueChange={handleChange}>
+    <div
+      className={cn(
+        "flex items-center gap-2 transition-opacity",
+        isPending && "opacity-70 pointer-events-none"
+      )}
+    >
+      <Select value={selectedChartId} onValueChange={handleChange}>
       <SelectTrigger className="w-[220px] border-zenshin-navy/15 text-zenshin-navy [&>span]:truncate">
         <SelectValue placeholder="全体" />
       </SelectTrigger>
@@ -47,5 +60,9 @@ export function DashboardChartFilter({
         ))}
       </SelectContent>
     </Select>
+      {isPending && (
+        <Loader2 className="h-4 w-4 animate-spin text-zenshin-navy/50 shrink-0" />
+      )}
+    </div>
   );
 }

--- a/app/dashboard/dashboard-period-filter.tsx
+++ b/app/dashboard/dashboard-period-filter.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import React, { useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import type { DateRange } from "react-day-picker";
+import { Loader2 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { CalendarIcon, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const PERIOD_OPTIONS = [
+  { value: "all", label: "全期間" },
+  { value: "this_month", label: "今月" },
+  { value: "last_month", label: "先月" },
+  { value: "this_quarter", label: "今四半期" },
+  { value: "last_quarter", label: "前四半期" },
+  { value: "this_year", label: "今年" },
+  { value: "custom", label: "カスタム" },
+] as const;
+
+function formatDateRange(fromStr: string, toStr: string): string {
+  const from = new Date(fromStr);
+  const to = new Date(toStr);
+  const sameYear = from.getFullYear() === to.getFullYear();
+  const fromFmt = sameYear ? format(from, "M/d", { locale: ja }) : format(from, "yyyy/M/d", { locale: ja });
+  const toFmt = sameYear ? format(to, "M/d", { locale: ja }) : format(to, "yyyy/M/d", { locale: ja });
+  return `${fromFmt} - ${toFmt}`;
+}
+
+type DashboardPeriodFilterProps = {
+  period: string;
+  from: string | null;
+  to: string | null;
+};
+
+export function DashboardPeriodFilter({
+  period,
+  from,
+  to,
+}: DashboardPeriodFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [rangeOpen, setRangeOpen] = React.useState(false);
+  const prevPeriodRef = React.useRef(period);
+
+  const updateParams = (updates: { period?: string; from?: string | null; to?: string | null }) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (updates.period !== undefined) {
+      if (updates.period === "all" || !updates.period) {
+        params.delete("period");
+        params.delete("from");
+        params.delete("to");
+      } else {
+        params.set("period", updates.period);
+        if (updates.period === "custom") {
+          if (updates.from) params.set("from", updates.from);
+          else params.delete("from");
+          if (updates.to) params.set("to", updates.to);
+          else params.delete("to");
+        } else {
+          params.delete("from");
+          params.delete("to");
+        }
+      }
+    } else if (updates.from !== undefined || updates.to !== undefined) {
+      if (updates.from !== undefined) {
+        if (updates.from) params.set("from", updates.from);
+        else params.delete("from");
+      }
+      if (updates.to !== undefined) {
+        if (updates.to) params.set("to", updates.to);
+        else params.delete("to");
+      }
+    }
+    const query = params.toString();
+    const newUrl = query ? `${pathname}?${query}` : pathname;
+    startTransition(() => {
+      router.push(newUrl, { scroll: false });
+    });
+  };
+
+  const handlePeriodChange = (value: string) => {
+    updateParams({ period: value });
+  };
+
+  // 「カスタム」を選択したときに自動でカレンダーを開く
+  React.useEffect(() => {
+    if (period === "custom" && prevPeriodRef.current !== "custom") {
+      setRangeOpen(true);
+    }
+    prevPeriodRef.current = period;
+  }, [period]);
+
+  const handleClearCustom = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    updateParams({ period: "all" });
+  };
+
+  const dateRange: DateRange | undefined =
+    from && to
+      ? {
+          from: new Date(from),
+          to: new Date(to),
+        }
+      : from
+        ? { from: new Date(from), to: undefined }
+        : undefined;
+
+  const handleRangeSelect = (range: DateRange | undefined) => {
+    if (!range) {
+      updateParams({ from: null, to: null });
+      return;
+    }
+    const fromStr = range.from ? format(range.from, "yyyy-MM-dd") : null;
+    const toStr = range.to ? format(range.to, "yyyy-MM-dd") : null;
+    updateParams({ from: fromStr, to: toStr });
+    if (range.from && range.to) {
+      setRangeOpen(false);
+    }
+  };
+
+  const isCustom = period === "custom";
+  const hasCustomDates = isCustom && from && to;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 transition-opacity",
+        isPending && "opacity-70 pointer-events-none"
+      )}
+    >
+      {!isCustom ? (
+        <Select value={period || "all"} onValueChange={handlePeriodChange}>
+          <SelectTrigger className="w-[180px] border-zenshin-navy/15 text-zenshin-navy [&>span]:truncate">
+            <SelectValue placeholder="全期間" />
+          </SelectTrigger>
+          <SelectContent>
+            {PERIOD_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <div className="flex h-9 w-[180px] items-center overflow-hidden rounded-md border border-zenshin-navy/15 bg-transparent text-sm">
+          <Popover open={rangeOpen} onOpenChange={setRangeOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  "flex flex-1 items-center gap-2 px-3 py-2 text-left font-normal min-w-0 h-full hover:bg-zenshin-navy/5 transition-colors",
+                  hasCustomDates ? "text-zenshin-navy" : "text-zenshin-navy/50"
+                )}
+              >
+                <CalendarIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">
+                  {hasCustomDates ? formatDateRange(from, to) : "日付を選択"}
+                </span>
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="range"
+                selected={dateRange}
+                onSelect={handleRangeSelect}
+                numberOfMonths={1}
+                defaultMonth={dateRange?.from ?? new Date()}
+              />
+            </PopoverContent>
+          </Popover>
+          <button
+            type="button"
+            onClick={handleClearCustom}
+            className="flex h-full shrink-0 items-center justify-center px-2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            title="全期間に戻す"
+            aria-label="全期間に戻す"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+      {isPending && (
+        <Loader2 className="h-4 w-4 animate-spin text-zenshin-navy/50 shrink-0" />
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,13 +1,13 @@
 export default function DashboardLoading() {
   return (
-    <div className="py-8 px-6 lg:px-10 min-h-screen animate-pulse">
+    <div className="py-8 px-6 lg:px-10 min-h-screen">
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <div className="h-7 w-44 bg-zenshin-navy/10 rounded-lg" />
-          <div className="h-4 w-52 bg-zenshin-navy/8 rounded mt-2" />
+          <div className="h-7 w-44 bg-zenshin-navy/10 rounded-lg animate-pulse" />
+          <div className="h-4 w-52 bg-zenshin-navy/8 rounded mt-2 animate-pulse" />
         </div>
-        <div className="h-9 w-48 bg-zenshin-navy/8 rounded-lg" />
+        <div className="h-9 w-48 bg-zenshin-navy/8 rounded-lg animate-pulse" />
       </div>
 
       {/* Summary Cards */}
@@ -18,18 +18,18 @@ export default function DashboardLoading() {
             className="bg-white rounded-xl border border-zenshin-navy/8 p-5"
           >
             <div className="flex items-center justify-between mb-3">
-              <div className="h-4 w-16 bg-zenshin-navy/8 rounded" />
-              <div className="h-4 w-4 bg-zenshin-navy/8 rounded" />
+              <div className="h-4 w-16 bg-zenshin-navy/8 rounded animate-pulse" />
+              <div className="h-4 w-4 bg-zenshin-navy/8 rounded animate-pulse" />
             </div>
-            <div className="h-9 w-16 bg-zenshin-navy/10 rounded-lg" />
+            <div className="h-9 w-16 bg-zenshin-navy/10 rounded-lg animate-pulse" />
           </div>
         ))}
       </div>
 
       {/* Status Distribution */}
       <div className="bg-white rounded-xl border border-zenshin-navy/8 p-5 mb-8">
-        <div className="h-5 w-32 bg-zenshin-navy/8 rounded mb-4" />
-        <div className="h-4 w-full bg-zenshin-navy/6 rounded-full" />
+        <div className="h-5 w-32 bg-zenshin-navy/8 rounded mb-4 animate-pulse" />
+        <div className="h-4 w-full bg-zenshin-navy/6 rounded-full animate-pulse" />
       </div>
 
       {/* Bottom sections */}
@@ -39,10 +39,10 @@ export default function DashboardLoading() {
             key={i}
             className="bg-white rounded-xl border border-zenshin-navy/8 p-5"
           >
-            <div className="h-5 w-36 bg-zenshin-navy/8 rounded mb-4" />
+            <div className="h-5 w-36 bg-zenshin-navy/8 rounded mb-4 animate-pulse" />
             <div className="space-y-3">
               {[1, 2, 3].map((j) => (
-                <div key={j} className="h-12 bg-zenshin-navy/4 rounded-lg" />
+                <div key={j} className="h-12 bg-zenshin-navy/4 rounded-lg animate-pulse" />
               ))}
             </div>
           </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,16 +10,20 @@ import {
 } from "lucide-react";
 import { getDashboardData } from "./actions";
 import { DashboardChartFilter } from "./dashboard-chart-filter";
+import { DashboardPeriodFilter } from "./dashboard-period-filter";
 
 export default async function DashboardPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ chartId?: string }>;
+  searchParams?: Promise<{ chartId?: string; period?: string; from?: string; to?: string }>;
 }) {
   const resolvedParams = await searchParams;
   const selectedChartId = resolvedParams?.chartId ?? "all";
+  const period = resolvedParams?.period ?? "all";
+  const from = resolvedParams?.from ?? null;
+  const to = resolvedParams?.to ?? null;
   const { stats, staleCharts, upcomingDeadlines, availableCharts } =
-    await getDashboardData(selectedChartId);
+    await getDashboardData(selectedChartId, period, from, to);
 
   return (
     <div className="py-8 px-6 lg:px-10 min-h-screen">
@@ -29,10 +33,13 @@ export default async function DashboardPage({
           <h1 className="text-2xl font-bold text-zenshin-navy">ダッシュボード</h1>
           <p className="text-sm text-zenshin-navy/40 mt-1">チャートの状況を俯瞰する</p>
         </div>
-        <DashboardChartFilter
-          charts={availableCharts}
-          selectedChartId={selectedChartId}
-        />
+        <div className="flex items-center gap-4 flex-wrap">
+          <DashboardPeriodFilter period={period} from={from} to={to} />
+          <DashboardChartFilter
+            charts={availableCharts}
+            selectedChartId={selectedChartId}
+          />
+        </div>
       </div>
 
       {/* サマリーカード */}

--- a/app/dashboard/utils.ts
+++ b/app/dashboard/utils.ts
@@ -1,0 +1,50 @@
+export type PeriodRange = { start: Date; end: Date } | null;
+
+export function getPeriodRange(
+  period: string | undefined | null,
+  from: string | undefined | null,
+  to: string | undefined | null
+): PeriodRange {
+  if (!period || period === "all") return null;
+  if (period === "custom") {
+    if (!from || !to) return null;
+    const start = new Date(from);
+    const end = new Date(to);
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+    return { start, end };
+  }
+
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  switch (period) {
+    case "this_month": {
+      const start = new Date(year, month, 1, 0, 0, 0, 0);
+      return { start, end: now };
+    }
+    case "last_month": {
+      const start = new Date(year, month - 1, 1, 0, 0, 0, 0);
+      const end = new Date(year, month, 0, 23, 59, 59, 999);
+      return { start, end };
+    }
+    case "this_quarter": {
+      const quarterMonth = Math.floor(month / 3) * 3;
+      const start = new Date(year, quarterMonth, 1, 0, 0, 0, 0);
+      return { start, end: now };
+    }
+    case "last_quarter": {
+      const quarterMonth = Math.floor(month / 3) * 3;
+      const start = new Date(year, quarterMonth - 3, 1, 0, 0, 0, 0);
+      const end = new Date(year, quarterMonth - 1, 0, 23, 59, 59, 999);
+      return { start, end };
+    }
+    case "this_year": {
+      const start = new Date(year, 0, 1, 0, 0, 0, 0);
+      return { start, end: now };
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## 概要

メインDashboardに期間フィルタを追加。Q単位での成果振り返りが可能に。

## 機能

- プリセット期間: 全期間 / 今月 / 先月 / 今四半期 / 前四半期 / 今年
- カスタム期間: Date Range Picker で任意の開始日〜終了日を選択
- chartId フィルタと併用可能

## 期間フィルタの対象

- アクション数・完了数・完了率・ステータス分布 → 期間でフィルタ
- チャート数・停滞チャート・期限切れアクション → 常に最新状態を表示

## UI/UX

- カスタム選択済み: 「📅 2/8 - 2/15 ✕」の統合ボタン表示
- ✕で全期間に戻る
- フィルタ切り替え時にローディングスケルトン表示（loading.tsx + useTransition）
- スクロール位置維持（scroll: false）

## 変更ファイル

- `app/dashboard/dashboard-period-filter.tsx`（新規）
- `app/dashboard/utils.ts`（新規）
- `app/dashboard/loading.tsx`（新規）
- `app/dashboard/actions.ts`
- `app/dashboard/page.tsx`
- `app/dashboard/dashboard-chart-filter.tsx`

## テスト結果

- [x] プリセット切り替えでデータが正しくフィルタされる
- [x] カスタム日付範囲で正しくフィルタされる
- [x] ローディングスケルトンが表示される
- [x] chartId フィルタと同時使用できる
- [x] ✕ボタンで全期間に戻る