### PR TITLE
feat: AI coach 3 modes - analyze, add info, free chat

### DIFF
--- a/app/api/ai/coach/route.ts
+++ b/app/api/ai/coach/route.ts
@@ -15,24 +15,92 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { chartData, messages, language } = await req.json();
-  if (!chartData) {
+  const { chartData, messages, language, mode = "analyze", text } = await req.json();
+  const isStructurize = mode === "structurize";
+
+  if (!isStructurize && !chartData) {
     return NextResponse.json({ error: "Chart data is required" }, { status: 400 });
   }
+  if (isStructurize && (!text || typeof text !== "string" || text.trim().length === 0)) {
+    return NextResponse.json({ error: "Text is required" }, { status: 400 });
+  }
 
-  const systemPrompt = language === "en" ? SYSTEM_PROMPT_EN : SYSTEM_PROMPT_JA;
+  const isChat = mode === "chat";
+  const systemPrompt = isStructurize
+    ? (language === "en" ? STRUCTURIZE_PROMPT_EN : STRUCTURIZE_PROMPT_JA)
+    : isChat
+      ? (language === "en" ? CHAT_SYSTEM_PROMPT_EN : CHAT_SYSTEM_PROMPT_JA)
+      : (language === "en" ? SYSTEM_PROMPT_EN : SYSTEM_PROMPT_JA);
+
+  if (isStructurize) {
+    const MAX_RETRIES = 3;
+    const RETRY_DELAYS = [2000, 5000, 10000];
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const message = await anthropic.messages.create({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 4000,
+          system: systemPrompt,
+          messages: [{ role: "user", content: text.slice(0, 8000) }],
+        });
+        const content = message.content[0];
+        if (content.type !== "text") {
+          return NextResponse.json({ error: "Unexpected response type" }, { status: 500 });
+        }
+        let jsonStr = content.text;
+        const jsonMatch = jsonStr.match(/```json\n?([\s\S]*?)\n?```/);
+        if (jsonMatch) {
+          jsonStr = jsonMatch[1];
+        } else {
+          const codeMatch = jsonStr.match(/```\n?([\s\S]*?)\n?```/);
+          if (codeMatch) jsonStr = codeMatch[1];
+        }
+        jsonStr = jsonStr.trim();
+        const result = JSON.parse(jsonStr);
+        if (!result.visions || !result.realities || !result.tensions || !result.actions) {
+          return NextResponse.json({ error: "Invalid AI response structure" }, { status: 500 });
+        }
+        return NextResponse.json(result);
+      } catch (parseError) {
+        if (parseError instanceof SyntaxError) {
+          console.error("JSON parse error:", parseError);
+          return NextResponse.json({ error: "Failed to parse AI response" }, { status: 500 });
+        }
+        const err = parseError as { status?: number; message?: string };
+        const status = err?.status || 500;
+        if (status === 529 && attempt < MAX_RETRIES - 1) {
+          console.log(`AI structurize: retrying (attempt ${attempt + 2}/${MAX_RETRIES})...`);
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS[attempt]));
+          continue;
+        }
+        console.error("AI structurize error:", err?.message || err);
+        const errorMessage = err?.message?.includes("credit")
+          ? "API credits insufficient"
+          : status === 529
+            ? "AI service is temporarily busy. Please try again in a moment."
+            : "AI processing failed";
+        return NextResponse.json({ error: errorMessage }, { status });
+      }
+    }
+    return NextResponse.json({ error: "AI processing failed after retries" }, { status: 500 });
+  }
+
   const chartContext = formatChartContext(chartData, language);
+  const lastContent =
+    messages?.length > 0
+      ? messages[messages.length - 1].content
+      : isChat
+        ? (language === "en"
+          ? "I'd like to ask about structural tension theory or my chart."
+          : "構造的テンション理論やチャートについて質問したいです。")
+        : (language === "en"
+          ? "Please analyze this chart and provide coaching."
+          : "このチャートを分析してコーチングしてください。");
 
   const aiMessages: Anthropic.MessageParam[] = [
     {
       role: "user",
-      content: `${chartContext}\n\n---\n\n${
-        messages?.length > 0
-          ? messages[messages.length - 1].content
-          : language === "en"
-            ? "Please analyze this chart and provide coaching."
-            : "このチャートを分析してコーチングしてください。"
-      }`,
+      content: `${chartContext}\n\n---\n\n${lastContent}`,
     },
   ];
 
@@ -225,7 +293,7 @@ const SYSTEM_PROMPT_JA = `あなたはZENSHIN CHARTのAIコーチです。ロバ
 | 問題がなくても同じビジョンを持つ | 問題がなければビジョンも消える |
 | 成功するほど動機が加速 | 成功するほど動機が減退 |
 
-**最も危険なのは2つのシステムの並存。** 表面上はビジョンを掲げて前進しているように見えるが、実際はシステム2が動機の大部分を占めている場合、業績改善→動機減退→揺り戻しが起きる。
+**注意**: 創造プロセスの中で問題解決的なアクションが混ざることは自然。見るべきは、創造プロセス全体がうまく機能しているかどうか。
 
 ### 重要性の階層（Hierarchy of Importance）
 複数の目標がある場合、**どちらが上位か**を明確に選択できているかどうかが構造を決める。
@@ -314,7 +382,7 @@ People and organizations are governed by underlying **structures** that create p
 | Same vision even without problems | Vision disappears without problems |
 | Success accelerates motivation | Success diminishes motivation |
 
-**Most dangerous: coexistence of both systems.** Surface-level vision pursuit masking System 2 dynamics leads to improvement → motivation loss → oscillation.
+**Note**: Problem-solving actions within a creative process are natural. What matters is whether the creative process as a whole is working.
 
 ### Hierarchy of Importance
 When multiple goals exist, whether the organization has clearly chosen **which is primary** determines the structure.
@@ -372,3 +440,97 @@ Signs of oscillating structure:
 - Use emojis sparingly (section dividers at most)
 - Maximum 3 questions at a time
 - If a vision appears to be "problem-solving" type, always point it out and ask "Would you want this even if there were no pain?"`;
+
+const STRUCTURIZE_PROMPT_JA = `あなたはロバート・フリッツの「構造的テンション」理論に基づいた構造化のエキスパートです。
+
+ユーザーが自由に語った内容を、以下の4つのカテゴリに構造化してください:
+
+1. **Vision（ビジョン）**: ユーザーが実現したい理想の状態。「〜ている」「〜できている」という完了形で表現する。
+2. **Reality（リアリティ）**: 現在の状況や事実。客観的に記述する。
+3. **Tension（テンション）**: ビジョンとリアリティのギャップから生まれる緊張。「〜できていない」「〜が不足している」等。
+4. **Action（アクション）**: テンションを解消するための具体的な行動。「誰が」「何を」「いつまでに」を含めることが望ましい。
+
+重要なルール:
+- Visionは「〜ている」「〜できている」と完了形で書く
+- Realityは客観的事実のみ、願望を含めない
+- TensionはVisionとRealityの差分から導出する
+- Actionは具体的で実行可能なものにする
+- 各カテゴリ最低1件、最大5件程度
+- Tensionには関連するActionを紐づける（tensionIndex で参照）
+
+必ず以下のJSON形式のみで返答してください。説明文やマークダウンは不要です:
+
+\`\`\`json
+{
+  "visions": [
+    { "title": "ビジョンの記述" }
+  ],
+  "realities": [
+    { "title": "リアリティの記述" }
+  ],
+  "tensions": [
+    { "title": "テンションの記述", "category": "uncategorized" }
+  ],
+  "actions": [
+    { "title": "アクションの記述", "tensionIndex": 0 }
+  ]
+}
+\`\`\`
+
+tensionIndex は tensions 配列の 0-based インデックスで、そのActionがどのTensionに紐づくかを示します。`;
+
+const STRUCTURIZE_PROMPT_EN = `You are an expert in structuring thoughts based on Robert Fritz's "Structural Tension" theory.
+
+Structure the user's free-form input into these 4 categories:
+
+1. **Vision**: The ideal state the user wants to achieve. Write in present tense as if already achieved ("We have...", "Our team is...").
+2. **Reality**: Current situation and facts. Objective description only.
+3. **Tension**: The gap between Vision and Reality. What's missing, what's not working.
+4. **Action**: Concrete steps to resolve the tension. Include who, what, and by when if possible.
+
+Important rules:
+- Vision should be written as if already achieved (present perfect or present tense)
+- Reality should contain only objective facts, no wishes
+- Tension should be derived from the gap between Vision and Reality
+- Actions should be specific and actionable
+- Each category: minimum 1, maximum ~5 items
+- Each Action should reference a Tension via tensionIndex
+
+Return ONLY the following JSON format. No explanation or markdown:
+
+\`\`\`json
+{
+  "visions": [
+    { "title": "Vision statement" }
+  ],
+  "realities": [
+    { "title": "Reality statement" }
+  ],
+  "tensions": [
+    { "title": "Tension statement", "category": "uncategorized" }
+  ],
+  "actions": [
+    { "title": "Action statement", "tensionIndex": 0 }
+  ]
+}
+\`\`\`
+
+tensionIndex is the 0-based index into the tensions array, indicating which Tension this Action addresses.`;
+
+const CHAT_SYSTEM_PROMPT_JA = `あなたはZENSHIN CHARTのAIアシスタントです。ロバート・フリッツの「構造的テンション（Structural Tension）」理論と、ユーザーのチャートについて、自由な質問に答えます。
+
+## あなたの役割
+- 構造的テンション理論について分かりやすく説明する
+- チャートの内容について質問に答える
+- 問いを投げてユーザーの気づきを促す
+- 簡潔に、要点を絞って伝える
+- ユーザーの言語（日本語）で返答する`;
+
+const CHAT_SYSTEM_PROMPT_EN = `You are the AI Assistant of ZENSHIN CHART. You answer free-form questions about Robert Fritz's "Structural Tension" theory and the user's chart.
+
+## Your Role
+- Explain structural tension theory clearly
+- Answer questions about the chart content
+- Ask questions to prompt user insights
+- Be concise and focused
+- Respond in the user's language (English)`;

--- a/app/charts/[id]/project-editor.tsx
+++ b/app/charts/[id]/project-editor.tsx
@@ -83,6 +83,10 @@ import {
   removeArea,
   moveActionToTension,
   moveActionToLoose,
+  addVision,
+  addReality,
+  addTension,
+  addActionPlan,
 } from "./actions";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -120,7 +124,7 @@ import { useActionHandlers, _pendingScrollRestore } from "./hooks/useActionHandl
 import { useDetailPanel } from "./hooks/useDetailPanel";
 import { useDndHandlers } from "./hooks/useDndHandlers";
 import { WelcomeCard } from "@/components/ai-assistant/WelcomeCard";
-import { AICoachButton } from "@/components/ai-coach-button";
+import { AICoachButton, type StructuredItems } from "@/components/ai-coach-button";
 import { collectChartDataForAI } from "@/lib/ai/collect-chart-data";
 
 const CalendarComponent = dynamic(
@@ -2614,6 +2618,35 @@ export function ProjectEditor({
             chart.areas ?? [],
             workspaceMembers
           )}
+          chartId={chart.id}
+          onAddItems={async (items: StructuredItems) => {
+            // 1. Vision追加
+            for (const v of items.visions) {
+              await addVision(chart.id, v.title);
+            }
+            // 2. Reality追加
+            for (const r of items.realities) {
+              await addReality(chart.id, r.title);
+            }
+            // 3. Tension追加（IDを保持してAction紐付けに使う）
+            const newTensionIds: string[] = [];
+            for (const t of items.tensions) {
+              const result = await addTension(chart.id, t.title);
+              if (result?.id) {
+                newTensionIds.push(result.id);
+              }
+            }
+            // 4. Action追加（tensionIndexで新Tensionに紐付け）
+            for (const a of items.actions) {
+              const idx = a.tensionIndex;
+              if (typeof idx === "number" && idx >= 0 && newTensionIds[idx]) {
+                await addActionPlan(newTensionIds[idx], a.title, null, chart.id);
+              }
+              // tensionIndex === -1 は既存Tension向け（今回はスキップ）
+            }
+            // ページを更新してデータを反映
+            router.refresh();
+          }}
         />
     </div>
   );

--- a/components/ai-coach-button.tsx
+++ b/components/ai-coach-button.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useTranslations, useLocale } from "next-intl";
-import { Bot, X, Send, Loader2, Sparkles } from "lucide-react";
+import { Bot, X, Send, Loader2, Sparkles, ArrowLeft, Target, Search, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import type { ChartDataForAI } from "@/lib/ai/collect-chart-data";
 
 interface Message {
@@ -11,18 +13,34 @@ interface Message {
   content: string;
 }
 
-interface AICoachButtonProps {
-  chartData: ChartDataForAI;
+export interface StructurizeResult {
+  visions: { title: string }[];
+  realities: { title: string }[];
+  tensions: { title: string; category?: string }[];
+  actions: { title: string; tensionIndex?: number }[];
 }
 
-export function AICoachButton({ chartData }: AICoachButtonProps) {
+export type StructuredItems = StructurizeResult;
+
+interface AICoachButtonProps {
+  chartData: ChartDataForAI;
+  chartId?: string;
+  onAddItems?: (items: StructurizeResult) => Promise<void>;
+}
+
+type ViewMode = "select" | "analyze" | "chat" | "add";
+
+export function AICoachButton({ chartData, chartId, onAddItems }: AICoachButtonProps) {
   const t = useTranslations("aiCoach");
   const locale = useLocale();
   const [isOpen, setIsOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>("select");
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [hasInitialAnalysis, setHasInitialAnalysis] = useState(false);
+  const [addText, setAddText] = useState("");
+  const [addResult, setAddResult] = useState<StructurizeResult | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -35,22 +53,38 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
   }, [messages]);
 
   useEffect(() => {
-    if (isOpen && inputRef.current) {
+    if (isOpen && inputRef.current && (viewMode === "analyze" || viewMode === "chat")) {
       inputRef.current.focus();
     }
-  }, [isOpen]);
+  }, [isOpen, viewMode]);
 
-  const sendMessage = async (userMessage?: string) => {
+  const handleOpen = () => {
+    setIsOpen(true);
+    setViewMode("select");
+    setMessages([]);
+    setInput("");
+    setAddText("");
+    setAddResult(null);
+  };
+
+  const handleBack = () => {
+    setViewMode("select");
+    setMessages([]);
+    setInput("");
+    setAddText("");
+    setAddResult(null);
+  };
+
+  const sendAnalyzeMessage = async (userMessage?: string) => {
     const messageToSend = userMessage ?? input.trim();
-    if (!messageToSend && hasInitialAnalysis) return;
+    if (!messageToSend && messages.length === 0) return;
 
-    const newMessages: Message[] = hasInitialAnalysis
-      ? [...messages, { role: "user" as const, content: messageToSend }]
-      : messages;
+    const newMessages: Message[] =
+      messages.length > 0
+        ? [...messages, { role: "user" as const, content: messageToSend }]
+        : [{ role: "user" as const, content: messageToSend }];
 
-    if (hasInitialAnalysis) {
-      setMessages(newMessages);
-    }
+    setMessages(newMessages);
     setInput("");
     setIsLoading(true);
 
@@ -60,10 +94,9 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           chartData,
-          messages: hasInitialAnalysis
-            ? newMessages.map((m) => ({ role: m.role, content: m.content }))
-            : [],
+          messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
           language: locale,
+          mode: "analyze",
         }),
       });
 
@@ -76,7 +109,6 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
         ...newMessages,
         { role: "assistant", content: data.response },
       ]);
-      setHasInitialAnalysis(true);
     } catch (error) {
       console.error("AI Coach error:", error);
       setMessages([
@@ -93,27 +125,322 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
     }
   };
 
-  const handleOpen = () => {
-    setIsOpen(true);
-    if (!hasInitialAnalysis && messages.length === 0) {
-      sendMessage(
-        locale === "en"
-          ? "Please analyze this chart and provide coaching."
-          : "このチャートを分析してコーチングしてください。"
-      );
+  const sendChatMessage = async (userMessage?: string) => {
+    const messageToSend = userMessage ?? input.trim();
+    if (!messageToSend) return;
+
+    const newMessages: Message[] = [...messages, { role: "user" as const, content: messageToSend }];
+    setMessages(newMessages);
+    setInput("");
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("/api/ai/coach", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chartData,
+          messages: newMessages.map((m) => ({ role: m.role, content: m.content })),
+          language: locale,
+          mode: "chat",
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("API request failed");
+      }
+
+      const data = await res.json();
+      setMessages([
+        ...newMessages,
+        { role: "assistant", content: data.response },
+      ]);
+    } catch (error) {
+      console.error("AI Coach error:", error);
+      setMessages([
+        ...newMessages,
+        {
+          role: "assistant",
+          content: locale === "en"
+            ? "Sorry, an error occurred. Please try again."
+            : "申し訳ありません、エラーが発生しました。もう一度お試しください。",
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCategorize = async () => {
+    if (!addText.trim()) return;
+    setIsLoading(true);
+    setAddResult(null);
+
+    try {
+      const res = await fetch("/api/ai/coach", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: addText.trim(),
+          language: locale,
+          mode: "structurize",
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("API request failed");
+      }
+
+      const data = await res.json();
+      setAddResult(data);
+    } catch (error) {
+      console.error("Structurize error:", error);
+      setAddResult({
+        visions: [],
+        realities: [],
+        tensions: [],
+        actions: [],
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleConfirmAdd = async () => {
+    if (!addResult || !onAddItems) return;
+    setIsAdding(true);
+    try {
+      await onAddItems(addResult);
+      setAddResult(null);
+      setAddText("");
+      setViewMode("select");
+    } catch (error) {
+      console.error("Add items error:", error);
+    } finally {
+      setIsAdding(false);
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
-      sendMessage();
+      if (viewMode === "analyze") sendAnalyzeMessage();
+      else if (viewMode === "chat") sendChatMessage();
     }
+  };
+
+  const renderContent = () => {
+    if (viewMode === "select") {
+      return (
+        <div className="p-4 space-y-3">
+          <p className="text-sm font-medium text-zenshin-navy">{t("modeSelect.title")}</p>
+          <div className="space-y-2">
+            <button
+              onClick={() => {
+                setViewMode("analyze");
+                setMessages([]);
+                sendAnalyzeMessage(
+                  locale === "en"
+                    ? "Please analyze this chart and provide coaching."
+                    : "このチャートを分析してコーチングしてください。"
+                );
+              }}
+              className="w-full text-left p-3 rounded-xl border border-gray-200 hover:bg-violet-50 hover:border-violet-200 transition-colors flex gap-3"
+            >
+              <Target className="w-5 h-5 text-violet-500 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium text-sm text-zenshin-navy">{t("modeSelect.analyze")}</p>
+                <p className="text-xs text-zenshin-navy/60">{t("modeSelect.analyzeDesc")}</p>
+              </div>
+            </button>
+            <button
+              onClick={() => {
+                setViewMode("chat");
+                setMessages([]);
+              }}
+              className="w-full text-left p-3 rounded-xl border border-gray-200 hover:bg-violet-50 hover:border-violet-200 transition-colors flex gap-3"
+            >
+              <Search className="w-5 h-5 text-violet-500 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium text-sm text-zenshin-navy">{t("modeSelect.chat")}</p>
+                <p className="text-xs text-zenshin-navy/60">{t("modeSelect.chatDesc")}</p>
+              </div>
+            </button>
+            <button
+              onClick={() => setViewMode("add")}
+              className="w-full text-left p-3 rounded-xl border border-gray-200 hover:bg-violet-50 hover:border-violet-200 transition-colors flex gap-3"
+            >
+              <Plus className="w-5 h-5 text-violet-500 shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium text-sm text-zenshin-navy">{t("modeSelect.add")}</p>
+                <p className="text-xs text-zenshin-navy/60">{t("modeSelect.addDesc")}</p>
+              </div>
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    if (viewMode === "add") {
+      return (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <div className="p-4 overflow-y-auto flex-1">
+            {!addResult ? (
+              <>
+                <p className="text-sm text-zenshin-navy/80 mb-3">{t("add.description")}</p>
+                <Textarea
+                  value={addText}
+                  onChange={(e) => setAddText(e.target.value)}
+                  placeholder={t("add.placeholder")}
+                  className="min-h-[120px] resize-none text-sm"
+                  disabled={isLoading}
+                />
+                <Button
+                  onClick={handleCategorize}
+                  disabled={isLoading || !addText.trim()}
+                  className="mt-3 w-full"
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                      {t("add.categorizing")}
+                    </>
+                  ) : (
+                    t("add.submit")
+                  )}
+                </Button>
+              </>
+            ) : (
+              <div className="space-y-4">
+                <p className="text-sm font-medium text-zenshin-navy">{t("add.preview")}</p>
+                {addResult.visions.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-violet-600 mb-1">Vision</p>
+                    <ul className="text-sm space-y-1">
+                      {addResult.visions.map((v, i) => (
+                        <li key={i} className="pl-2 border-l-2 border-violet-200">• {v.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {addResult.realities.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-teal-600 mb-1">Reality</p>
+                    <ul className="text-sm space-y-1">
+                      {addResult.realities.map((r, i) => (
+                        <li key={i} className="pl-2 border-l-2 border-teal-200">• {r.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {addResult.tensions.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-amber-600 mb-1">Tension</p>
+                    <ul className="text-sm space-y-1">
+                      {addResult.tensions.map((t, i) => (
+                        <li key={i} className="pl-2 border-l-2 border-amber-200">• {t.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {addResult.actions.length > 0 && (
+                  <div>
+                    <p className="text-xs font-medium text-blue-600 mb-1">Action</p>
+                    <ul className="text-sm space-y-1">
+                      {addResult.actions.map((a, i) => (
+                        <li key={i} className="pl-2 border-l-2 border-blue-200">• {a.title}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setAddResult(null)}
+                    disabled={isAdding}
+                    className="flex-1"
+                  >
+                    {t("add.discard")}
+                  </Button>
+                  <Button
+                    onClick={handleConfirmAdd}
+                    disabled={isAdding || !onAddItems}
+                    className="flex-1"
+                  >
+                    {isAdding ? <Loader2 className="w-4 h-4 animate-spin" /> : t("add.confirm")}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // analyze or chat
+    const isAnalyze = viewMode === "analyze";
+    const sendMessage = isAnalyze ? sendAnalyzeMessage : sendChatMessage;
+    const greeting = isAnalyze ? t("greeting") : t("chat.greeting");
+    const placeholder = isAnalyze ? t("inputPlaceholder") : t("chat.inputPlaceholder");
+
+    return (
+      <>
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {messages.length === 0 && !isLoading && (
+            <div className="text-center text-gray-400 text-sm mt-8">
+              <Sparkles className="w-8 h-8 mx-auto mb-3 text-violet-300" />
+              <p>{greeting}</p>
+            </div>
+          )}
+          {messages.map((msg, i) => (
+            <div
+              key={i}
+              className={cn(
+                "text-sm leading-relaxed",
+                msg.role === "user"
+                  ? "bg-violet-50 text-violet-900 rounded-2xl rounded-br-md px-4 py-2.5 ml-8"
+                  : "text-gray-700"
+              )}
+            >
+              <div className="whitespace-pre-wrap">{msg.content}</div>
+            </div>
+          ))}
+          {isLoading && (
+            <div className="flex items-center gap-2 text-gray-400 text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>{t("analyzing")}</span>
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <div className="border-t p-3 shrink-0">
+          <div className="flex items-end gap-2">
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              className="flex-1 resize-none rounded-xl border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-300 max-h-24"
+              rows={1}
+              disabled={isLoading}
+            />
+            <button
+              onClick={() => sendMessage()}
+              disabled={isLoading || !input.trim()}
+              className="p-2 rounded-xl bg-violet-500 text-white hover:bg-violet-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
+            >
+              <Send className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </>
+    );
   };
 
   return (
     <>
-      {/* Floating Button */}
       {!isOpen && (
         <button
           onClick={handleOpen}
@@ -124,12 +451,18 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
         </button>
       )}
 
-      {/* Chat Panel */}
       {isOpen && (
         <div className="fixed bottom-6 right-6 z-50 w-[380px] h-[560px] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
-          {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-violet-500 to-indigo-600 text-white shrink-0">
             <div className="flex items-center gap-2">
+              {viewMode !== "select" && (
+                <button
+                  onClick={handleBack}
+                  className="p-1 hover:bg-white/20 rounded transition-colors"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                </button>
+              )}
               <Bot className="w-5 h-5" />
               <span className="font-bold text-sm">{t("title")}</span>
             </div>
@@ -141,58 +474,7 @@ export function AICoachButton({ chartData }: AICoachButtonProps) {
             </button>
           </div>
 
-          {/* Messages */}
-          <div className="flex-1 overflow-y-auto p-4 space-y-4">
-            {messages.length === 0 && !isLoading && (
-              <div className="text-center text-gray-400 text-sm mt-8">
-                <Sparkles className="w-8 h-8 mx-auto mb-3 text-violet-300" />
-                <p>{t("greeting")}</p>
-              </div>
-            )}
-            {messages.map((msg, i) => (
-              <div
-                key={i}
-                className={cn(
-                  "text-sm leading-relaxed",
-                  msg.role === "user"
-                    ? "bg-violet-50 text-violet-900 rounded-2xl rounded-br-md px-4 py-2.5 ml-8"
-                    : "text-gray-700"
-                )}
-              >
-                <div className="whitespace-pre-wrap">{msg.content}</div>
-              </div>
-            ))}
-            {isLoading && (
-              <div className="flex items-center gap-2 text-gray-400 text-sm">
-                <Loader2 className="w-4 h-4 animate-spin" />
-                <span>{t("analyzing")}</span>
-              </div>
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-
-          {/* Input */}
-          <div className="border-t p-3 shrink-0">
-            <div className="flex items-end gap-2">
-              <textarea
-                ref={inputRef}
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={t("inputPlaceholder")}
-                className="flex-1 resize-none rounded-xl border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-300 max-h-24"
-                rows={1}
-                disabled={isLoading}
-              />
-              <button
-                onClick={() => sendMessage()}
-                disabled={isLoading || !input.trim()}
-                className="p-2 rounded-xl bg-violet-500 text-white hover:bg-violet-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
-              >
-                <Send className="w-4 h-4" />
-              </button>
-            </div>
-          </div>
+          {renderContent()}
         </div>
       )}
     </>

--- a/messages/en.json
+++ b/messages/en.json
@@ -668,8 +668,32 @@
   },
   "aiCoach": {
     "title": "AI Coach",
-    "greeting": "Ask me anything about your chart. I'll analyze and coach you.",
+    "greeting": "Analyzing your chart...",
     "analyzing": "Analyzing...",
-    "inputPlaceholder": "Ask a question..."
+    "inputPlaceholder": "Type a message...",
+    "back": "Back",
+    "modeSelect": {
+      "title": "What would you like to do?",
+      "analyze": "Analyze Chart",
+      "analyzeDesc": "Analyze your chart with Fritz's structural tension theory",
+      "add": "Add Chart Info",
+      "addDesc": "Extract V/R/T/A from text and add to your chart",
+      "chat": "Ask Freely",
+      "chatDesc": "Ask about structural tension theory or your chart"
+    },
+    "chat": {
+      "greeting": "Ask me anything about your chart or Fritz's structural tension theory.",
+      "inputPlaceholder": "Type your question..."
+    },
+    "add": {
+      "description": "Paste your text below. AI will categorize it into Vision / Reality / Tension / Action items.",
+      "placeholder": "e.g., Revenue has grown 120% YoY. New customer acquisition channels are established. Currently relying on existing customers with only ~5 new leads per month...",
+      "submit": "Categorize",
+      "categorizing": "Categorizing your text...",
+      "preview": "The following items will be added:",
+      "confirm": "Add to Chart",
+      "discard": "Start Over",
+      "success": "Added to your chart!"
+    }
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -668,8 +668,32 @@
   },
   "aiCoach": {
     "title": "AIコーチ",
-    "greeting": "チャートについて何でも聞いてください。分析してコーチングします。",
+    "greeting": "チャートを分析しています...",
     "analyzing": "分析中...",
-    "inputPlaceholder": "質問を入力..."
+    "inputPlaceholder": "メッセージを入力...",
+    "back": "戻る",
+    "modeSelect": {
+      "title": "何をしますか？",
+      "analyze": "チャートを分析",
+      "analyzeDesc": "現在のチャートをフリッツ理論で分析・コーチング",
+      "add": "チャート情報を追加",
+      "addDesc": "テキストからV/R/T/Aに振り分けて追加",
+      "chat": "自由に質問",
+      "chatDesc": "構造的テンション理論やチャートについて質問"
+    },
+    "chat": {
+      "greeting": "なんでも聞いてください。チャートの内容やフリッツ理論について、お答えします。",
+      "inputPlaceholder": "質問を入力..."
+    },
+    "add": {
+      "description": "追加したい内容をテキストで入力してください。AIがVision / Reality / Tension / Actionに振り分けます。",
+      "placeholder": "例: 売上が前年比120%に達している。新規顧客の獲得チャネルが確立されている。現在は既存顧客中心で新規は月5件程度...",
+      "submit": "振り分ける",
+      "categorizing": "テキストを振り分けています...",
+      "preview": "以下の項目が追加されます：",
+      "confirm": "チャートに追加",
+      "discard": "やり直す",
+      "success": "チャートに追加しました！"
+    }
   }
 }


### PR DESCRIPTION
- Mode selection screen on button press (no auto-analyze)
- Analyze mode: existing coaching with Fritz structural dynamics
- Add mode: paste text → AI categorizes into V/R/T/A → preview → add to chart
- Chat mode: free-form Q&A about structural tension theory
- Updated system prompts: creative process includes problem-solving naturally
- onAddItems callback connects to project-editor for DB persistence
- Added translation keys for all 3 modes (ja/en)
- Unified all AI calls through /api/ai/coach endpoint