### PR TITLE
fix: workspace_members 取得で profiles 埋め込みを分割クエリ化する #86exb8667

### DIFF
--- a/app/workspaces/[wsId]/settings/members/page.tsx
+++ b/app/workspaces/[wsId]/settings/members/page.tsx
@@ -26,21 +26,43 @@ export default async function MembersPage({
 
   if (!membership) redirect("/");
 
-  // Query workspace members directly instead of calling getWorkspaceMembers()
-  // which is in a "use server" file and may lose auth context.
-  const { data: memberRows } = await supabase
+  // Step 1: workspace_members を取得
+  const { data: memberRows, error: memberError } = await supabase
     .from("workspace_members")
-    .select(`user_id, role, profiles(email, name, avatar_url)`)
+    .select("user_id, role")
     .eq("workspace_id", wsId);
 
-  const members = (memberRows || []).map((m) => {
-    const profile = m.profiles as unknown as { email?: string; name?: string; avatar_url?: string } | null;
+  if (memberError) {
+    console.error("[MembersPage] workspace_members error:", memberError);
+  }
+
+  // Step 2: profiles を別クエリで取得
+  const userIds = (memberRows ?? []).map((m) => m.user_id);
+
+  const { data: profileRows, error: profileError } = userIds.length > 0
+    ? await supabase
+        .from("profiles")
+        .select("id, email, name, avatar_url")
+        .in("id", userIds)
+    : { data: [] as { id: string; email: string | null; name: string | null; avatar_url: string | null }[], error: null };
+
+  if (profileError) {
+    console.error("[MembersPage] profiles error:", profileError);
+  }
+
+  // Step 3: コード側で merge
+  const profileMap = new Map(
+    (profileRows ?? []).map((p) => [p.id, p])
+  );
+
+  const members = (memberRows ?? []).map((m) => {
+    const p = profileMap.get(m.user_id);
     return {
       id: m.user_id,
-      email: profile?.email || "",
-      name: profile?.name,
+      email: p?.email || "",
+      name: p?.name || undefined,
       role: m.role,
-      avatar_url: profile?.avatar_url,
+      avatar_url: p?.avatar_url || undefined,
     };
   });
 

--- a/lib/workspace.ts
+++ b/lib/workspace.ts
@@ -238,27 +238,40 @@ export async function getWorkspaceMembers(workspaceId: string): Promise<
 > {
   const supabase = await createClient();
 
-  const { data: members } = await supabase
+  const { data: memberRows, error: memberError } = await supabase
     .from("workspace_members")
-    .select(
-      `
-      user_id,
-      role,
-      profiles(email, name, avatar_url)
-    `
-    )
+    .select("user_id, role")
     .eq("workspace_id", workspaceId);
 
-  if (!members) return [];
+  if (memberError) {
+    console.error("[getWorkspaceMembers] workspace_members error:", memberError);
+  }
 
-  return members.map((m) => {
-    const profile = m.profiles as unknown as { email?: string; name?: string; avatar_url?: string } | null;
+  if (!memberRows || memberRows.length === 0) return [];
+
+  const userIds = memberRows.map((m) => m.user_id);
+
+  const { data: profileRows, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, email, name, avatar_url")
+    .in("id", userIds);
+
+  if (profileError) {
+    console.error("[getWorkspaceMembers] profiles error:", profileError);
+  }
+
+  const profileMap = new Map(
+    (profileRows ?? []).map((p) => [p.id, p])
+  );
+
+  return memberRows.map((m) => {
+    const p = profileMap.get(m.user_id);
     return {
       id: m.user_id,
-      email: profile?.email || "",
-      name: profile?.name,
+      email: p?.email || "",
+      name: p?.name || undefined,
       role: m.role,
-      avatar_url: profile?.avatar_url,
+      avatar_url: p?.avatar_url || undefined,
     };
   });
 }


### PR DESCRIPTION
PostgREST の埋め込み構文 .select("user_id, role, profiles(...)") が workspace_members と profiles の間に直接 FK が無いため失敗し、
memberRows が null 扱いで空配列に落ちていた問題を修正。

app/workspaces/[wsId]/settings/members/page.tsx: 埋め込み廃止、 workspace_members と profiles を 2 クエリ化、Map で merge、各々エラーログ追加 lib/workspace.ts:getWorkspaceMembers: 同パターンへ変更

影響: 全 workspace の Members ページとチャートエディタのアサイニー候補。
lib/workspace-search.ts の searchWorkspaceMembers も同パターンだが Surgical Changes 原則に従い別タスクで対応。
検証は Vercel デプロイ後、本番で Kaz が実施。