### PR TITLE
fix: DetailsEditor の Enter キーでカーソルが末尾に飛ぶ問題を修正 (#86exbhew3)

### DIFF
--- a/components/unified-detail-modal/DetailsEditor.tsx
+++ b/components/unified-detail-modal/DetailsEditor.tsx
@@ -37,11 +37,6 @@ export function DetailsEditor({
   const latestValueRef = useRef(value);
   const editorRef = useRef<ReturnType<typeof useEditor>>(null);
 
-  // 親のvalueが変わったら追跡
-  useEffect(() => {
-    latestValueRef.current = value;
-  }, [value]);
-
   const debouncedSave = useCallback((html: string) => {
     const trimmed = html === "<p></p>" ? "" : html;
     if (trimmed === latestValueRef.current) return;
@@ -104,8 +99,13 @@ export function DetailsEditor({
   }, [editor]);
 
   useEffect(() => {
-    if (editor && value !== undefined) {
+    if (
+      editor &&
+      value !== undefined &&
+      value !== latestValueRef.current
+    ) {
       editor.commands.setContent(value || "<p></p>", { emitUpdate: false });
+      latestValueRef.current = value;
     }
   }, [editor, value]);
 


### PR DESCRIPTION
本番の origin/main でも発生している既存バグを修正。

問題: Enter 押下 → onUpdate → debouncedSave → 親 state 更新 → re-render で value prop が戻ってくる → useEffect が発火して setContent を実行する結果、 ProseMirror の selection がリセットされてカーソルが末尾に飛ぶ。

修正:
- 値追跡専用の useEffect (latestValueRef.current = value) を削除
- setContent を呼ぶ useEffect に value !== latestValueRef.current のガードを追加
- ガード成立時のみ setContent + latestValueRef.current の更新を実行
- latestValueRef の更新点を debouncedSave と統合 useEffect の 2 箇所に限定

Refs: #86exbhew3
Made-with: Cursor